### PR TITLE
RF: move MultipleReleaseFileMatch to live along with other exceptions

### DIFF
--- a/niceman/retrace/packagemanagers.py
+++ b/niceman/retrace/packagemanagers.py
@@ -21,6 +21,7 @@ import pytz
 from datetime import datetime
 
 import niceman.utils as utils
+from niceman.support.exceptions import MultipleReleaseFileMatch
 
 try:
     import apt
@@ -271,9 +272,6 @@ class DpkgManager(PackageManager):
         lgr.debug("Found package %s", pkg)
         return pkg
 
-    class MultipleReleaseFileMatch(RuntimeError):
-        pass
-
     def _find_release_date(self, site, archive):
         if not site:
             return None
@@ -291,7 +289,7 @@ class DpkgManager(PackageManager):
                             "dists_%s_%s" % (archive, relfile))
                     if os.path.exists(dirname + name):
                         if rfile:
-                            raise self.MultipleReleaseFileMatch(
+                            raise MultipleReleaseFileMatch(
                                 "More than one release file found for %s %s" %
                                 (site, archive))
                         rfile = dirname + name

--- a/niceman/support/exceptions.py
+++ b/niceman/support/exceptions.py
@@ -54,3 +54,8 @@ class MissingConfigError(RuntimeError):
 class MissingConfigFileError(RuntimeError):
     """To be raised when missing the configuration file"""
     pass
+
+
+class MultipleReleaseFileMatch(RuntimeError):
+    """Multiple release files were matched while retracing on Debian"""
+    pass


### PR DESCRIPTION
I think this is more kosher/easier to locate/use although I can see some kind of value to bind it to the class... so up to you @rbuccigrossi 